### PR TITLE
Updates the deprecated `source_files.list`

### DIFF
--- a/assets/properties/source_files.list
+++ b/assets/properties/source_files.list
@@ -1,10 +1,10 @@
-src/com/mitsuki/jmatrix/IllegalMatrixSizeException.java
-src/com/mitsuki/jmatrix/InvalidIndexException.java
 src/com/mitsuki/jmatrix/Main.java
 src/com/mitsuki/jmatrix/Matrix.java
-src/com/mitsuki/jmatrix/MatrixArrayFullException.java
-src/com/mitsuki/jmatrix/NullMatrixException.java
+src/com/mitsuki/jmatrix/core/IllegalMatrixSizeException.java
+src/com/mitsuki/jmatrix/core/InvalidIndexException.java
 src/com/mitsuki/jmatrix/core/JMBaseException.java
+src/com/mitsuki/jmatrix/core/MatrixArrayFullException.java
+src/com/mitsuki/jmatrix/core/NullMatrixException.java
 src/com/mitsuki/jmatrix/util/OSUtils.java
 src/com/mitsuki/jmatrix/util/Options.java
 src/com/mitsuki/jmatrix/util/XMLParser.java


### PR DESCRIPTION
Updating this file will make users who don't use `Python`, can compile the program using `Java` only.

### Example
Compiling the program
```bash|powershell
javac -d bin/ @assets/properties/source_files.list
```

Creating the jar file
```bash|powershell
jar cvfm jmatrix.jar META-INF/MANIFEST.MF LICENSE assets/ -C bin/ .
```