### PR TITLE
Fixes missing input variable at `setup-java@v3`

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,6 +47,7 @@ jobs:
       if: ${{ matrix.language == 'java' }}
       uses: actions/setup-java@v3
       with:
+        distribution: temurin
         java-version: 11
 
     # Initializes the CodeQL tools for scanning.


### PR DESCRIPTION
This happened because previous `Setup JVM` used `setup-java` version 1, and doesn't need `distribution` variable. Previously `setup-java` got updated and immediately raise an error after merging. But now it has been fixed, [see here](https://github.com/mitsuki31/jmatrix/commit/d60315515b6287fe2a0534ab307b9304d782adfe).

Error message from CodeQL Analysis:
> Error: Input required and not supplied: distribution

For more details, see `setup-java` release notes at @dependabot comment (#14)