### PR TITLE
Fixes some issue on `MinGW` (Windows) 🪛

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,35 +77,36 @@ endif
 all:
 	$(info [Makefile-jmatrix])
 	@echo "Options:"
-	@echo "   * compile       - Compile the program. \
-		\n   * package       - Create archived package (jar) of compiled program.\
-		\n                        WARNING: Program need to be compiled first! \
-		\n   * clean         - Clean all of compiled program and created jar. \
-		\n   * cleanbin      - Clean all generated class files only. \
-		\n   * check-verbose - Check the verbose status. \
-		\n   * usage         - Print the example usages for build the project."
-
-	@echo "\nAdditional Options:"
+	@echo "   * compile       - Compile the program."
+	@echo "   * package       - Create archived package (jar) of compiled program."
+	@echo "                        WARNING: Program need to be compiled first!"
+	@echo "   * clean         - Clean all of compiled program and created jar."
+	@echo "   * cleanbin      - Clean all generated class files only."
+	@echo "   * check-verbose - Check the verbose status."
+	@echo "   * usage         - Print the example usages for build the project."
+	@echo ""
+	@echo "Additional Options:"
 	@echo "   * Activating verbose output"
-
-	@echo "\n       \`export VERBOSE=true\`"
-	@echo "\n     Or:"
-	@echo "\n       \`make [options] VERBOSE=true\`\n"
-
+	@echo ""
+	@echo "       \`export VERBOSE=true\`"
+	@echo ""
+	@echo "     Or:"
+	@echo ""
+	@echo "       \`make [options] VERBOSE=true\`"
+	@echo ""
+	@echo ""
 	@echo "   * Include source files while packaging"
-
-	@echo "\n       \`export INCLUDE-SRC=true\`"
-	@echo "\n     Or:"
-	@echo "\n       \`make [options] INCLUDE-SRC=true\`\n"
-
-	@echo "\nUsage:"
-	@echo "     $$ make [option1] [option2] [...]"
-	@echo "     $$ make compile package"
-
-	@echo "\nTips:"
+	@echo ""
+	@echo "       \`make [options] INCLUDE-SRC=true\`"
+	@echo ""
+	@echo "Usage:"
+	@echo "     $$ make [options] [...] [arguments]"
+	@echo "     $$ make [options] VERBOSE[=<bool>] INCLUDE-SRC[=<bool>]"
+	@echo ""
+	@echo "Tips:"
 	@echo "   - Combine the options, Makefile can understand multiple rules."
-
-	@echo "\nAuthor:"
+	@echo ""
+	@echo "Author:"
 	@echo "   Ryuu Mitsuki"
 
 
@@ -119,16 +120,18 @@ endif
 
 
 compile: $(SOURCES_LIST) $(SRCFILES)
-	@echo "\n>> [ COMPILE PROGRAM ] <<"
+	@echo ""
+	@echo ">> [ COMPILE PROGRAM ] <<"
 
 	@echo "$(PREFIX) Compiling all source files..."
 	@$(CC) -d $(CLASSES_PATH) @$<
-	@echo "$(PREFIX) Successfully compile all source files."
+	@echo "$(PREFIX) Successfully compiled all source files."
 
 	$(eval HAS_COMPILED := $(wildcard $(CLASSES_PATH)))
 	$(eval HAS_OUTPUT := $(wildcard $(OUTPUT_PATH)))
 
-	@echo "\n>> [ GENERATE LIST ] <<"
+	@echo ""
+	@echo ">> [ GENERATE LIST ] <<"
 	@echo "$(PREFIX) Generating list of class files..."
 
 ifeq "$(MAKE_VERBOSE)" "true"
@@ -145,12 +148,14 @@ package: $(CLSFILES)
 		$(error $(PREFIX) Program is uncompiled, compile it with `make compile` command)\
 	)
 
-	@echo "\n>> [ CREATE JAR ] <<"
+	@echo ""
+	@echo ">> [ CREATE JAR ] <<"
 
 	@echo "$(PREFIX) Copying all program resources to output directory..."
-	@cp -r $(RESOURCES_PATH)* $(CLASSES_PATH)
-	@echo "$(PREFIX) All resources have been copied.\n"
+	@cp -r --preserve=all $(RESOURCES_PATH)* $(CLASSES_PATH)
+	@echo "$(PREFIX) All resources have been copied."
 
+	@echo ""
 	@echo "$(PREFIX) Creating jar for compiled classes..."
 
 ifeq "$(MAKE_VERBOSE)" "true"
@@ -164,7 +169,8 @@ else
 endif
 
 ifeq "$(INCLUDE-SRC)" "true"
-	@echo "\n$(PREFIX) INCLUDE-SRC option is ACTIVATED"
+	@echo ""
+	@echo "$(PREFIX) INCLUDE-SRC option is ACTIVATED"
 	@echo "$(PREFIX) Adding the source files into jar..."
 ifeq "$(MAKE_VERBOSE)" "true"
 	@jar uvf $(jar) -C $(SOURCES_PATH) .
@@ -174,21 +180,26 @@ endif
 endif
 
 	@echo "$(PREFIX) Successfully created the jar file."
-	@echo "\nSAVED IN: \"$(jar)\""
+	@echo ""
+	@echo "SAVED IN: \"$(jar)\""
 
 
 clean:
-	@echo "\n>> [ CLEAN WORKING DIRECTORY ] <<"
+	@echo ""
+	@echo ">> [ CLEAN WORKING DIRECTORY ] <<"
 	@echo "$(PREFIX) Cleaning the \"$(OUTPUT_PATH)\" directory recursively..."
 	@-rm -r $(OUTPUT_PATH)
-	@echo "\n$(PREFIX) All cleaned up."
+	@echo ""
+	@echo "$(PREFIX) All cleaned up."
 
 
 cleanbin:
-	@echo "\n>> [ CLEAN ONLY CLASS OBJECTS ] <<"
+	@echo ""
+	@echo ">> [ CLEAN ONLY CLASS OBJECTS ] <<"
 	@echo "$(PREFIX) Cleaning the class files only..."
 	@-rm -r $(CLASSES_PATH)
-	@echo "\n$(PREFIX) All cleaned up."
+	@echo ""
+	@echo "$(PREFIX) All cleaned up."
 
 	$(if $(shell test -e $(jar) && echo "1"),\
 		@echo 'File "$(jar:/=)" is still exists.',\
@@ -197,7 +208,8 @@ cleanbin:
 
 
 $(SOURCES_LIST): $(wildcard $(PYTHON_PATH)*.py)
-	@echo "\n>> [ GENERATE LIST ] <<"
+	@echo ""
+	@echo ">> [ GENERATE LIST ] <<"
 	@echo "$(PREFIX) Generating list of source files..."
 
 ifeq "$(MAKE_VERBOSE)" "true"
@@ -210,22 +222,26 @@ endif
 
 
 usage:
-	@echo "[Makefile Usage]\n"
+	@echo "[Makefile Usage]"
 
-	@echo "Parameters:\n    $$ make [option1] [option2] [...]\n"
+	@echo ""
+	@echo "Parameters:"
+	@echo "    $$ make [option1] [option2] [...]"
 
+	@echo ""
 	@echo "Generate \"jar\" file (simple)"
-	@echo "\
-	make\n\
-	  └── compile\n\
-	          └── package\n\
-	                 └── cleanbin (optional)\n"
+	@echo ""
+	@echo "make"
+	@echo "  └── compile"
+	@echo "          └── package"
+	@echo "                 └── cleanbin (optional)"
 
+	@echo ""
 	@echo "Generate \"jar\" file (complex)"
-	@echo "\
-	make\n\
-	  └── compile\n\
-	         └── package\n\
-	                └── && mv target/*.jar .\n\
-	                       └── && make\n\
-	                              └── clean\n"
+	@echo ""
+	@echo "make"
+	@echo "  └── compile"
+	@echo "         └── package"
+	@echo "                └── && mv target/*.jar ."
+	@echo "                       └── && make"
+	@echo "                                └── clean"

--- a/Makefile
+++ b/Makefile
@@ -202,8 +202,8 @@ cleanbin:
 	@echo "$(PREFIX) All cleaned up."
 
 	$(if $(shell test -e $(jar) && echo "1"),\
-		@echo 'File "$(jar:/=)" is still exists.',\
-		$(warning File "$(jar_name)" is missing or has been deleted.)\
+		@echo 'File "$(subst ./,,$(jar))" is still exists.',\
+		@echo 'File "$(subst ./,,$(jar))" is missing or has been deleted.'\
 	)
 
 

--- a/src/main/java/com/mitsuki/jmatrix/util/XMLParser.java
+++ b/src/main/java/com/mitsuki/jmatrix/util/XMLParser.java
@@ -7,19 +7,14 @@ package com.mitsuki.jmatrix.util;
 
 // -**- Built-in Package -**- //
 import java.io.InputStream;
-import java.io.IOException;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.ParserConfigurationException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-import org.w3c.dom.DOMException;
 
 // -**- Local Package -**- //
 import com.mitsuki.jmatrix.core.JMBaseException;
-import com.mitsuki.jmatrix.util.Options;
 
 
 /**
@@ -147,15 +142,15 @@ public class XMLParser implements XMLData
             Document doc = docBuilder.parse(configStream);
             Element xml = doc.getDocumentElement();
 
-            XMLConfig.programName = xml.getElementsByTagName("program_name").item(0).getTextContent();
-            XMLConfig.author = xml.getElementsByTagName("author").item(0).getTextContent();
-            XMLConfig.version = xml.getElementsByTagName("version").item(0).getTextContent();
+            XMLConfig.programName = xml.getElementsByTagName("program_name").item(0).getTextContent().strip();
+            XMLConfig.author = xml.getElementsByTagName("author").item(0).getTextContent().strip();
+            XMLConfig.version = xml.getElementsByTagName("version").item(0).getTextContent().strip();
             XMLConfig.releaseType = xml.getElementsByTagName("version").item(0)
-                .getAttributes().getNamedItem("type").getNodeValue();
-            XMLConfig.packageName = xml.getElementsByTagName("package").item(0).getTextContent();
+                .getAttributes().getNamedItem("type").getNodeValue().strip();
+            XMLConfig.packageName = xml.getElementsByTagName("package").item(0).getTextContent().strip();
 
             if (!XMLConfig.version.equals("release")) {
-                XMLConfig.betaNum = xml.getElementsByTagName("beta_num").item(0).getTextContent();
+                XMLConfig.betaNum = xml.getElementsByTagName("beta_num").item(0).getTextContent().strip();
             }
         } catch (final Exception e) {
             try {

--- a/src/main/python/generate_list.py
+++ b/src/main/python/generate_list.py
@@ -6,14 +6,12 @@ __all__    = ['GenerateList']
 
 import os
 import sys
-import platform
 from utils import Utils, FileUtils
 
 class GenerateList:
     """
     This class provides methods that generates list of source files and class files.
-
-    For generating list, this class uses command that based on the operating system.
+    Currently only works on Linux/Unix system, Windows user need to install MinGW and Git Bash.
 
     Working directory:
         : 'src/main/java/' - For searching all of source files (*.java).
@@ -21,11 +19,11 @@ class GenerateList:
         : 'target/generated-list/' - The output directory for generated list.
     """
     __PATH: dict = {
-        ('target_path'): (os.sep).join(['src', 'main', 'java']),
-        ('class_path'): (os.sep).join(['target', 'classes']) + os.sep,
-        ('out_path'): (os.sep).join(['target', 'generated-list']) + os.sep,
-        ('source'): (os.sep).join(['target', 'generated-list', 'sourceFiles.lst']),
-        ('output'): (os.sep).join(['target', 'generated-list', 'outputFiles.lst'])
+        ('target_path'): ('/').join(['src', 'main', 'java']),
+        ('class_path'): ('/').join(['target', 'classes']) + '/',
+        ('out_path'): ('/').join(['target', 'generated-list']) + '/',
+        ('source'): ('/').join(['target', 'generated-list', 'sourceFiles.lst']),
+        ('output'): ('/').join(['target', 'generated-list', 'outputFiles.lst'])
     }
 
     __verbose: bool = False
@@ -125,10 +123,7 @@ class GenerateList:
         Raises:
             None
         """
-        if platform.system().lower() in ('linux', 'unix'):
-            command = self.__command['unix']['source']
-        elif platform.system().lower() in ('win', 'win32', 'win64', 'windows'):
-            command = self.__command['windows']['source']
+        command = self.__command['unix']['source']
 
         if self.__verbose:
             Utils.pr_banner('GENERATING LIST')
@@ -136,6 +131,7 @@ class GenerateList:
 
         err_code: int = os.system(command)
 
+        # Return if an error occured
         if err_code != 0:
             sys.exit(err_code)
 
@@ -178,10 +174,7 @@ class GenerateList:
         Raises:
             None
         """
-        if platform.system().lower() in ('linux', 'unix'):
-            cmd = self.__command['unix']['output']
-        elif platform.system().lower() in ('win', 'win32', 'win64', 'windows'):
-            cmd = self.__command['windows']['output']
+        cmd = self.__command['unix']['output']
 
         if self.__verbose:
             Utils.pr_banner('GENERATING LIST')
@@ -189,6 +182,7 @@ class GenerateList:
 
         err_code: int = os.system(cmd)
 
+        # Return if an error occured
         if err_code != 0:
             sys.exit(err_code)
 
@@ -209,7 +203,7 @@ class GenerateList:
 
         for output_file in output_lst:
             for out in output_file.split():
-                new_output_lst.append(os.path.join(*(out.split(os.sep)[2:])))
+                new_output_lst.append(os.path.join(*(out.split('/')[2:])))
         new_output_lst.sort()
 
         if self.__verbose:


### PR DESCRIPTION
## What's Changed
- Changed the newline character (`\n`) in `Makefile` with `echo ""`. ([457a3f2](https://github.com/mitsuki31/jmatrix/commit/457a3f29fbc4ba1f89ada772af64dd871c6f701e))
- Update the message on `cleanbin` rule in `Makefile`. ([1666711](https://github.com/mitsuki31/jmatrix/commit/16667112dd4bcd9b075b91ddd129074f7f4abf37))
- Fixes unable to compile issue on **Windows** when using `make`. ([a868ad9](https://github.com/mitsuki31/jmatrix/commit/a868ad9d31955c969886590a2f65e16fb43ef2d5))
- Fixes trailing whitespaces. ([37dd3b5](https://github.com/mitsuki31/jmatrix/commit/37dd3b5188917a325840af292710262cec4ecf60))

## Description
The messages which printed by `make` is always prints the `\n` as text instead treating it as a newline character on **Windows** with [**Git Bash**][git-bash] and [**MinGW**][mingw] installed. On my device (**Linux**), it works well but if I'm using `-e` flag it would just prints the given flag.
```make
@echo -e "some message"
# Output: e some message
```

So to make it fair, I've changed the newline with the implicit one (print a blank message with `echo`).

More details, see below:
https://github.com/mitsuki31/jmatrix/blob/457a3f29fbc4ba1f89ada772af64dd871c6f701e/Makefile#L96-L102

---

Besides that, there's some issue that the `javac` command unable to compile, because the given source files list (`sourceFiles.lst`) has **Windows** file separator (`\`).
In that case, `javac` treats it as flag then raise an error `invalid flag: "\"`.
Once again, this issue only occur on **Windows** system.

So, I've once again changed the newline character from `os.sep` (based on operating system) to **Unix**-based separator (`/`). See below:
https://github.com/mitsuki31/jmatrix/blob/a868ad9d31955c969886590a2f65e16fb43ef2d5/src/main/python/generate_list.py#L22-L26

And also instead using command based on operating system (that would cause an error when using [**Git Bash**][git-bash]), the command to retrieve the sources and classes files now uses **Unix** command (which supports [**Git Bash**][git-bash]) both **Windows** and **Unix** system.

https://github.com/mitsuki31/jmatrix/blob/a868ad9d31955c969886590a2f65e16fb43ef2d5/src/main/python/generate_list.py#L126-L132

---

Also I've encountered some issue with the output message that given by command `java -jar "path/to/jmatrix.jar" -V`, and this only occurred when using `make` to build the project (on **Windows** with [**MinGW**][mingw] installed).
So here I've fixed it by adding `strip()` method after retrieving the config on `config.xml` (the `config.xml` itself is generated by [**Python**](https://python.org) program).

https://github.com/mitsuki31/jmatrix/blob/37dd3b5188917a325840af292710262cec4ecf60/src/main/java/com/mitsuki/jmatrix/util/XMLParser.java#L145-L150


## Summary
All of bugs and issues above only occurred on **Windows** operating system. And now it has been fixed and tested on **Windows 10** with [**Git Bash**][git-bash] as shell environment and [**MinGW**][mingw] installed.

> **Note** It is recommended to use [**Git Bash**][git-bash] instead **Command Prompt** or **Powershell** for shell environment if want to build the project using `make` (also make sure you've [**MinGW**][mingw] installed).
> Or if you want a simple one, try using [**Maven**][maven]. It supports both **Command Prompt** and **Powershell**.


[git-bash]: https://git-scm.com/
[mingw]: https://sourceforge.net/projects/mingw/
[maven]: https://maven.apache.org/