### PR TITLE
Now `pylint` also tests with Python3.7

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       # Checkout the repo
       - name: Checkout repository


### PR DESCRIPTION
## Summary
Not a major changes, only added the **Python** v3.7 into `pylint` workflows,
so `pylint` would also checks and tests the **Python** programs on **Python** v3.7.