### PR TITLE
Now `getSize` would returns `null` when get called from matrix with `null` entries

### DIFF
--- a/src/main/java/com/mitsuki/jmatrix/Matrix.java
+++ b/src/main/java/com/mitsuki/jmatrix/Matrix.java
@@ -77,7 +77,7 @@ import java.util.Arrays;
  *
  * @author   <a href="https://github.com/mitsuki31" target="_blank">
  *           Ryuu Mitsuki</a>
- * @version  1.8, 16 June 2023
+ * @version  1.9, 19 June 2023
  * @since    0.1.0
  * @license  <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">
  *           Apache License 2.0</a>
@@ -2745,7 +2745,9 @@ public class Matrix implements MatrixUtils {
     /**
      * Retrieves the sizes (also known as, number of rows and columns) of this matrix.
      *
-     * <p>If the entries of this matrix is {@code null} it will returns zero for both sizes.
+     * <p>If the entries of this matrix is {@code null} it will returns {@code null} instead.
+     * This also prevents unexpected results that could be happen when comparing the matrix sizes.<br>
+     * To check whether the matrix has {@code null} entries, please refer to {@link MatrixUtils#isNullEntries(Matrix)}.
      *
      * <p><b>For example:</b></p>
      *
@@ -2774,6 +2776,9 @@ public class Matrix implements MatrixUtils {
      * @see    #getEntries()
      */
     public int[ ] getSize() {
+        // Now if this matrix has null entries, then returns null
+        if (this.ENTRIES == null) return null;
+
         // It would return list: [<rows>, <cols>]
         return new int[ ] { this.ROWS, this.COLS };
     }

--- a/src/test/java/com/mitsuki/jmatrix/test/Test_MatrixConstructor.java
+++ b/src/test/java/com/mitsuki/jmatrix/test/Test_MatrixConstructor.java
@@ -14,7 +14,8 @@ public class Test_MatrixConstructor {
 
         assertEquals(true, MatrixUtils.isNullEntries(x));
         assertEquals(true, (x.getEntries() == null));
-        assertEquals(true, (0 == x.getSize()[0] && 0 == x.getSize()[1]));
+        assertEquals(null, x.getSize());
+        assertEquals(null, y.getSize());
         assertEquals(true, x.equals(y));
 
         y.create(new double[][] { {5, 5}, {4, 4} });  // initialize new entries


### PR DESCRIPTION
## Summary

Now `getSize` method no longer returns `[0, 0]` if this matrix has null entries, instead it would returns `null`.
This also prevents the unexpected results when comparing the matrix sizes.

**Previously:**
```java
Matrix m = new Matrix();
System.out.println(m.getSize());  // [0, 0]
```

**After this update:**
```java
Matrix m = new Matrix();
System.out.println(m.getSize());  // null
```

> **Note** This changes was following the `MatrixUtils.isEqualsSize` algorithm, which is returns `false` instead if the given matrices has `null` entries.
> https://github.com/mitsuki31/jmatrix/blob/2ba56f1e0751c1b5e640417d10dfdf9f151ef69d/src/main/java/com/mitsuki/jmatrix/util/MatrixUtils.java?plain=1#L119-L127
>
> Previously there was a known issue, when comparing with `isEqualsSize` it would returns `false` and if comparing each size manually it returns `true`. Here's the example to make it more clear:
> ```java
> Matrix m = new Matrix();
> Matrix n = new Matrix();
>
> // Compare size using "isEqualsSize"
> System.out.println(MatrixUtils.isEqualsSize(m, n));  // false
>
> // Compare size manually
> System.out.println(
>     (m.getSize()[0] == n.getSize()[0] &&
>      m.getSize()[1] == n.getSize()[1]));    // true
> ```