### PR TITLE
Javadoc improvements for JMatrix 📚

### DIFF
--- a/src/main/java/com/mitsuki/jmatrix/Main.java
+++ b/src/main/java/com/mitsuki/jmatrix/Main.java
@@ -32,13 +32,26 @@ import com.mitsuki.jmatrix.util.XMLParser;
  *
  * @author   <a href="https://github.com/mitsuki31" target="_blank">
  *           Ryuu Mitsuki</a>
- * @version  1.31, 27 June 2023
+ * @version  1.32, 19 July 2023
  * @since    1.0.0b.1
  * @see      com.mitsuki.jmatrix.Matrix
  */
 public class Main
 {
+    /**
+     * Stores the static object class of {@link XMLParser} class.
+     */
     private static XMLParser XML = new XMLParser(XMLParser.XMLType.CONFIG);
+
+    /**
+     * Stores a string that represents the concatenation of:
+     *
+     * <ul>
+     *  <li>The program name
+     *  <li>(a space)
+     *  <li>The version number
+     * </ul>
+     */
     private static String programVersion = XML.getProperty("programName") + " " + getVersion();
 
     /**
@@ -100,6 +113,15 @@ public class Main
         }
     }
 
+
+    /**
+     * Gets the version number and concanate it with the release type.
+     * And concanate again with the beta number if and only if the release type is "beta".
+     *
+     * @return a string represents the version number.
+     *
+     * @since  1.0.0
+     */
     private static String getVersion() {
         String ver = XML.getProperty("version");
 

--- a/src/main/java/com/mitsuki/jmatrix/util/OSUtils.java
+++ b/src/main/java/com/mitsuki/jmatrix/util/OSUtils.java
@@ -35,6 +35,7 @@ import java.io.File;
  */
 public class OSUtils
 {
+
     /**
      * List names of operating system.
      *
@@ -44,9 +45,35 @@ public class OSUtils
      * @see   #getOSName()
      */
     public enum OS {
-        WINDOWS, LINUX, MAC, SOLARIS, OTHER
+        /**
+         * Indicates the Windows OS.
+         */
+        WINDOWS,
+
+        /**
+         * Indicates the Linux OS.
+         */
+        LINUX,
+
+        /**
+         * Indicates the Mac OS.
+         */
+        MAC,
+
+        /**
+         * Indicates the Solaris OS.
+         */
+        SOLARIS,
+
+        /**
+         * Indicates unknown OS.
+         */
+        OTHER
     };
 
+    /**
+     * Stores the static variable of {@link OSUtils.OS}.
+     */
     private static OS os = null;
 
     /**

--- a/src/main/java/com/mitsuki/jmatrix/util/Options.java
+++ b/src/main/java/com/mitsuki/jmatrix/util/Options.java
@@ -35,7 +35,7 @@ import java.util.Arrays;
  *
  * @author   <a href="https://github.com/mitsuki31" target="_blank">
  *           Ryuu Mitsuki</a>
- * @version  1.31, 18 July 2023
+ * @version  1.32, 19 July 2023
  * @since    1.0.0b.1
  * @license  <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">
  *           Apache License 2.0</a>
@@ -46,28 +46,81 @@ public class Options
 {
 
     /**
-     * {@code Enum} that contains all available options.
+     * An {@code Enum} that contains all available options.
      *
      * @since 1.0.0b.1
      * @see   #getOptions(String)
      */
     public enum OPT {
+
+        /**
+         * Represents the "version" option. Users can retrieve this option by using one of the following inputs:
+         *
+         * <ul>
+         *  <li>{@code -V}
+         *  <li>{@code ver}
+         *  <li>{@code version}
+         * </ul>
+         *
+         * @see #OPT(String...)
+         */
         VERSION("-V", "version", "ver"),
+
+        /**
+         * Represents the "help" option. Users can retrieve this option by using the following input:
+         *
+         * <ul>
+         *  <li>{@code -h}
+         *  <li>{@code help}
+         * </ul>
+         *
+         * @see #OPT(String...)
+         */
         HELP("-h", "help"),
+
+        /**
+         * Represents the "copyright" option. Users can retrieve this option by using the following input:
+         *
+         * <ul>
+         *  <li>{@code -cr}
+         *  <li>{@code copyright}
+         * </ul>
+         *
+         * @see #OPT(String...)
+         */
         COPYRIGHT("-cr", "copyright");
 
+        /**
+         * A {@link List} of string to stores all options aliases.
+         */
         private final List<String> aliases;
 
+        /**
+         * Constructs an option with the given aliases.
+         *
+         * @param aliases  the aliases that represent this option.
+         *
+         * @since          1.0.0b.1
+         * @see            java.util.Arrays#asList
+         */
         OPT(String ... aliases) {
             this.aliases = Arrays.asList(aliases);
         }
     }
 
-    // -- Private Attributes
+    /**
+     * Stores the static object of {@link XMLParser} class.
+     */
     private static XMLParser XML = new XMLParser(XMLParser.XMLType.CONFIG);
+
+    /**
+     * Stores a string that represents the program name.
+     */
     private static String PROGNAME = XML.getProperty("programName").toLowerCase();
-    private static String PACKAGE = getPackageName(Options.class);
-    private static String THISCLASS = getClassName(Options.class);
+
+    /**
+     * Stores a string that represents the path to "contents" directory.
+     */
     private static String contentsPath = "contents/";
 
     /**

--- a/src/main/java/com/mitsuki/jmatrix/util/XMLParser.java
+++ b/src/main/java/com/mitsuki/jmatrix/util/XMLParser.java
@@ -32,18 +32,42 @@ import org.w3c.dom.Element;
  *
  * @author   <a href="https://github.com/mitsuki31" target="_blank">
  *           Ryuu Mitsuki</a>
- * @version  1.21, 18 July 2023
+ * @version  1.22, 19 July 2023
  * @since    1.0.0b.1
  * @license  <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">
  *           Apache License 2.0</a>
  */
 class XMLConfig
 {
+    /**
+     * Stores a string that represents the program name.
+     */
     static String programName = null;
+
+    /**
+     * Stores a string that represents the version number of <b>JMatrix</b> library.
+     */
     static String version = null;
+
+    /**
+     * Stores a string that represents the beta number. For example, X.Y.Z-beta.<b>1</b>, where 1 is the beta number.
+     */
     static String betaNum = null;
+
+    /**
+     * Stores a string that represents the author name.
+     */
     static String author = null;
+
+    /**
+     * Stores a string that represents the package name of <b>JMatrix</b> library.
+     */
     static String packageName = null;
+
+    /**
+     * Stores a string represents the release type of <b>JMatrix</b> library.
+     * The value can be "release", "beta" or "stable".
+     */
     static String releaseType = null;
 }
 
@@ -52,13 +76,23 @@ class XMLConfig
  *
  * @author   <a href="https://github.com/mitsuki31" target="_blank">
  *           Ryuu Mitsuki</a>
- * @version  1.2, 26 June 2023
+ * @version  1.22, 19 July 2023
  * @since    1.0.0b.1
  * @license  <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">
  *           Apache License 2.0</a>
  */
 interface XMLData
 {
+
+    /**
+     * Gets the property data from the specified input string.
+     *
+     * @param  choice  a string to search the property data.
+     *
+     * @return         the property data.
+     *
+     * @since          1.0.0b.1
+     */
     static String getData(final String choice) {
         String data = null;
 
@@ -100,11 +134,12 @@ interface XMLData
 
 
 /**
- * This class provides requirements to parse XML document.
+ * This class provides requirements to parse the XML document, which is used to retrieves the
+ * required properties for <b>JMatrix</b> library.
  *
  * @author   <a href="https://github.com/mitsuki31" target="_blank">
  *           Ryuu Mitsuki</a>
- * @version  1.2, 26 June 2023
+ * @version  1.22, 19 July 2023
  * @since    1.0.0b.1
  * @license  <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank">
  *           Apache License 2.0</a>
@@ -121,11 +156,21 @@ public class XMLParser implements XMLData
      * @see   #getCurrentType()
      */
     public static enum XMLType {
+        /**
+         * Represents the "config" option.
+         */
         CONFIG
     };
 
-    // -- Private Attributes
+
+    /**
+     * Stores the object class of {@link XMLType} class.
+     */
     private XMLType xmlType = null;
+
+    /**
+     * Stores a static string represents the path of configuration file.
+     */
     private final static String configPath = "configuration/config.xml";
 
     /**


### PR DESCRIPTION
What's Changed
--------------

- Javadoc documentation has been added to several classes to provide comprehensive explanations and improve code clarity.
  > This update also addresses the documentation warning encountered during project linting.
  > For more information, see #58.

<details><summary><b>All Commits</b></summary>

- 046e9fa - Add and update the javadoc for `Main`
- e26435c - Add and update the javadoc for `OSUtils`
- 52e6ffa - Add and update the javadoc for `XMLParser`
- a154dbd - Add and update the javadoc for `Options`

</details>

Summary
-------

This set of changes focuses on enhancing code documentation by adding Javadoc to multiple classes. The newly added Javadoc provides comprehensive explanations for the respective classes, contributing to better code clarity and understanding.
Additionally, this update successfully resolves the documentation warning encountered during project linting (#58). The improvements in code documentation enhance the overall maintainability and readability of the codebase.
