### PR TITLE
fix: Correct `arraycopy` source and destination in `dropRow` method

### DIFF
--- a/src/main/java/com/mitsuki/jmatrix/Matrix.java
+++ b/src/main/java/com/mitsuki/jmatrix/Matrix.java
@@ -1279,7 +1279,7 @@ public class Matrix implements MatrixUtils {
         double[][] newEntries = new double[rows - 1][cols];
         for (int i = 0, destRow = 0; i < rows; i++) {
             if (i == row) continue;  // Skip the desired row index
-            System.arraycopy(newEntries[destRow++], 0, entries[i], 0, cols);
+            System.arraycopy(entries[i], 0, newEntries[destRow++], 0, cols);
         }
 
         return new Matrix(newEntries);


### PR DESCRIPTION
## Overview

This pull request addresses an issue in the `Matrix` class where the `System.arraycopy` method was used incorrectly in the `dropRow` method. Specifically, the source and destination parameters in `System.arraycopy` were swapped, which led to improper handling of row removal from the matrix.

## Changes Made

- Corrected the usage of `System.arraycopy`:
  - **Source Parameter**: Updated from `newEntries[destRow++]` to `entries[i]`.
  - **Destination Parameter**: Updated from `entries[i]` to `newEntries[destRow++]`.

These changes ensure that the correct row data is copied from the original matrix to the new matrix after a row has been dropped.

### Reason for the Change

The initial implementation of `System.arraycopy` mistakenly swapped the source and destination arrays. As a result, the `dropRow` method did not correctly transfer data from the original matrix to the new matrix, potentially leading to incorrect matrix content.

## Impact

This fix corrects the behavior of row removal in the `Matrix` class, ensuring that the matrix operations produce accurate results. Users of the `Matrix` class should experience improved reliability when performing row deletions.
