### PR TITLE
fix: Fix matrix row and column insertion boundaries

### DIFF
--- a/src/main/java/com/mitsuki/jmatrix/Matrix.java
+++ b/src/main/java/com/mitsuki/jmatrix/Matrix.java
@@ -682,7 +682,7 @@ public class Matrix implements MatrixUtils {
                 "Given array is null or empty. Cannot append it into the matrix")));
         }
 
-        return Matrix.insertRow(m, m.getNumRows() - 1, a);
+        return Matrix.insertRow(m, m.getNumRows(), a);
     }
 
 
@@ -800,7 +800,7 @@ public class Matrix implements MatrixUtils {
                 "Given array is null or empty. Cannot append it into the matrix")));
         }
 
-        return Matrix.insertColumn(m, m.getNumCols() - 1, a);
+        return Matrix.insertColumn(m, m.getNumCols(), a);
     }
 
 
@@ -953,7 +953,7 @@ public class Matrix implements MatrixUtils {
         } else if (a == null || a.length == 0) {  // Check for null or empty array
             raise(new JMatrixBaseException(new NullPointerException(
                 "Given array is null or empty. Cannot insert it into the matrix")));
-        } else if (row < 0 || row >= mRows) {  // Check for the index is out of bounds
+        } else if (row < 0 || row > mRows) {  // Check for the index is out of bounds
             raise(new InvalidIndexException(
                 String.format("Given row index is out of range: %d",
                     (row < 0) ? (row - mRows - 1) : row


### PR DESCRIPTION
## Overview

This pull request addresses issues related to row and column insertion boundaries in the `Matrix` class, as well as correcting index checks for matrix operations. The changes ensure that rows and columns can be inserted correctly at the end of the matrix and that boundary conditions are handled appropriately, avoiding potential index out of bounds errors.

## Changes Made

### Row Insertion Correction

- Updated the `Matrix.insertRow()` method to insert a new row at the correct position. Previously, the insertion was occurring at `m.getNumRows() - 1`, which placed the new row one index before the end of the matrix. The new implementation corrects this to `m.getNumRows()`, allowing for proper insertion at the end of the matrix.

### Column Insertion Correction

- Modified the `Matrix.insertColumn()` method similarly to insert a new column at `m.getNumCols()` instead of `m.getNumCols() - 1`. This ensures that columns are appended correctly at the end of the matrix.

### Boundary Check Adjustment
- The boundary check for row indices in the matrix insertion logic has been updated. The condition previously checked for `row >= mRows`, which incorrectly excluded valid insertions at the last row index. The updated check now allows insertions at `row > mRows`, accommodating valid operations at the matrix's end.

## Impact

### Functionality
These fixes ensure that the matrix operations for row and column insertions behave as expected, allowing elements to be appended to the end of the matrix. The corrected boundary checks prevent out-of-bounds errors and ensure robust matrix operations.

### Backward Compatibility
The changes maintain backward compatibility with existing matrix operations, as they only correct boundary conditions and insertion indices without altering the fundamental behavior of the matrix methods.
