### PR TITLE
fix: Fix and update custom Javadoc tags in Makefile

### DIFF
--- a/make/Setup.mk
+++ b/make/Setup.mk
@@ -163,10 +163,10 @@ ifndef __intern_INC_SRC
 endif  # __intern_INC_SRC
 
 # Get current year using Python datetime module
-__current_year := $(shell $(PY) -c "import datetime as date; print(date.datetime.now().year)")
+__current_year     := $(shell $(PY) -c "import datetime as date; print(date.datetime.now().year)")
 
-# Window title for HTML docs "JMatrix API"
-__jdoc_WIN_TITLE   := "$(PROGNAME) API"
+# Window title for HTML docs "JMatrix <VERSION> API"
+__jdoc_WIN_TITLE   := "$(PROGNAME) $(VERSION) API"
 
 # Custom Javadoc tags
 __jdoc_CUSTOM_TAGS := -tag param                                    \

--- a/make/Setup.mk
+++ b/make/Setup.mk
@@ -169,9 +169,16 @@ __current_year := $(shell $(PY) -c "import datetime as date; print(date.datetime
 __jdoc_WIN_TITLE   := "$(PROGNAME) API"
 
 # Custom Javadoc tags
-__jdoc_CUSTOM_TAGS := -tag param -tag return -tag throws     \
-                      -tag warning:a:"Warning:" -tag author  \
-                      -tag license:pt:"License:" -tag see
+__jdoc_CUSTOM_TAGS := -tag param                                    \
+                      -tag return                                   \
+                      -tag throws                                   \
+                      -tag warning:a:"Warning:"                     \
+                      -tag apiNote:ptcmf:"API Note:"                \
+                      -tag implNote:ptcmf:"Implementation Note:"    \
+                      -tag author                                   \
+                      -tag license:pt:"License:"                    \
+                      -tag see
+
 
 # Custom bottom page; Must be closed with quotes!
 __jdoc_BOTTOM      := 'Copyright &copy; $(INCEPTION_YEAR) - $(__current_year) <a href="$(AUTHOR_URL)">$(AUTHOR)</a>. All rights reserved.'


### PR DESCRIPTION
## Overview

This pull request addresses two key issues related to the generation of Javadoc using the Makefile for the project. The changes ensure that custom Javadoc tags are properly configured and the window title for the HTML documentation is consistent with the format generated by Maven builds. These improvements align the Javadoc generation process across both build systems (Make and Maven), ensuring uniformity in the documentation's appearance and structure.

## Changes Made

### Fix: Custom Javadoc Tags Configuration

- Updated the custom Javadoc tags in the Makefile to match the Javadoc configuration specified in the `pom.xml` file.
- Added missing custom tags, including:
 - `@apiNote` (for providing API notes),
 - `@implNote` (for implementation-specific notes).
- This ensures that these tags are recognized and rendered correctly in the generated documentation.

### Refactor: Javadoc Window Title Update

- Modified the window title in the generated Javadoc to include both the program name and version (e.g., "JMatrix 1.5.0 API") for consistency with the Maven-generated Javadoc.
- The title now reflects the correct format across different build tools, providing a better user experience when browsing the API documentation.

## Impact

- **Consistency Across Builds**: The updated Javadoc tags and window title ensure that the Javadoc generated using the Makefile is consistent with that generated by Maven. This avoids discrepancies in documentation across different build environments.
- **Improved Documentation**: Adding the missing custom Javadoc tags (`@apiNote`, `@implNote`) improves the quality of the generated API documentation, making it more informative for developers by highlighting important notes related to APIs and implementations.
- **Better User Experience**: With the updated window title format, users viewing the generated documentation will see a clear and consistent representation of the project and its version, enhancing navigation and clarity.

## Summary

This pull request fixes missing custom Javadoc tags and updates the Javadoc window title in the Makefile. The changes ensure consistency between the Makefile and Maven builds, aligning the Javadoc generation process across both. This improves the quality of the documentation and provides a better user experience for developers. 
