### PR TITLE
fix: Fix build process issues in Maven and Make build configurations

### DIFF
--- a/make/Main.mk
+++ b/make/Main.mk
@@ -147,7 +147,7 @@ ifeq ($(__intern_INC_SRC),1)
 	$(call __info,Generating the JAR file (sources)...)
 	@$(JAR) $(subst {JAR},$(lastword $(JAR_NAMES)),$(JARFLAGS)) \
 		$(wildcard LICENSE) -C $(JAVA_DIR) . \
-		-C $(addprefix $(CLASSES_DIR)/,$(notdir $(RESOURCES_ONLY_DIR))) .
+		-C $(CLASSES_DIR) $(notdir $(RESOURCES_ONLY_DIR))
 	$(call __info,$(subst {JAR},$(abspath $(lastword $(JAR_NAMES))),$(._done_msg)))
 endif  # __intern_INC_SRC
 	$(eval undefine ._done_msg)

--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,11 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <!-- It is mandatory to include hard-formatted manifest file -->
+                            <useDefaultManifestFile>true</useDefaultManifestFile>
+                            <defaultManifestFile>${paths.classesDir}/MANIFEST.MF</defaultManifestFile>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Overview

This pull request addresses critical issues in the build processes for both Maven and Make, ensuring that resource directories and manifest files are correctly included during packaging. These changes ensure that the build outputs (JAR files) are structured as expected and include all necessary resources and metadata.

## Changes Made

### Make build process

- Fixed the Make build script to include resource directories during the JAR creation. This resolves the issue where only resource files were being added without their corresponding directories.

### Maven build process

- Updated the Maven `maven-source-plugin:jar-no-fork` configuration to ensure the default `MANIFEST.MF` file is included in the JAR source package. This was missing due to an incorrect configuration in the `pom.xml`.

## Impact

### Make build

- Resource directories are now correctly packaged in the JAR file, preventing runtime issues caused by misplaced resource files.

### Maven build

- The manifest file is now properly included in the JAR source package, ensuring that the package contains the necessary metadata for proper usage and distribution.

## Summary

These changes resolve critical issues in both the Maven and Make build processes, ensuring that resource directories and manifest files are properly packaged in JAR files. This ensures the integrity of build artifacts and avoids future problems during deployments or distribution.
